### PR TITLE
Return flag write types

### DIFF
--- a/src/architecture.rs
+++ b/src/architecture.rs
@@ -333,9 +333,7 @@ impl Architecture for Msp430 {
     }
 
     fn flag_write_types(&self) -> Vec<Self::FlagWrite> {
-        //TODO: fix this once FlagClasses are understood
-        //vec![FlagWrite::All, FlagWrite::Cnz]
-        vec![]
+        vec![FlagWrite::All, FlagWrite::Nz, FlagWrite::Nvz, FlagWrite::Cnz]
     }
 
     fn flag_classes(&self) -> Vec<Self::FlagClass> {


### PR DESCRIPTION
This was originally commented out due to a bug in Binary Ninja that
caused the python scripting provider to break when it attempted to
lookup invalid flag classes. The rust bindings were incorrectly
returning the flag write type id rather than the flag class id which
would always have a non-zero value when flag writes exist even if a flag
class does not.